### PR TITLE
Add clang-tidy static analysis

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,54 @@
+---
+Checks:    "bugprone-*,\
+            cert-*,\
+            clang-analyzer-*,\
+            google-*,\
+            llvm-*,\
+            misc-*,\
+            modernize-*,\
+            performance-*,\
+            readability-*,\
+            -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,\
+            -google-readability-braces-around-statements,\
+            -google-readability-todo,\
+            -llvm-header-guard,\
+            -modernize-use-trailing-return-type,\
+            -readability-misleading-indentation"
+WarningsAsErrors:   '*'
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           0
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ClassConstantCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ClassConstantPrefix
+    value:           'k'
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.FunctionCase
+    value:           lower_case
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.GlobalConstantPrefix
+    value:           'G_'
+  - key:             readability-identifier-naming.MemberCase
+    value:           lower_case
+  - key:             readability-identifier-naming.NamespaceCase
+    value:           lower_case
+  - key:             readability-identifier-naming.PublicMemberSuffix
+    value:           ''
+  - key:             readability-identifier-naming.PrivateMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.ProtectedMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.MethodCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ParameterCase
+    value:           lower_case
+  - key:             readability-identifier-naming.VariableCase
+    value:           lower_case
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,11 @@ cmake_minimum_required(VERSION 3.12.2)
 
 project (control VERSION 0.34.0)
 
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+include(configure_tidy)
 include(CTest)
+
+option(SECONTROL_CLANG_TIDY "Build with clang-tidy static analysis" OFF)
 
 add_subdirectory(doc)
 add_subdirectory(src)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,6 @@
 .checkpatch.conf		@mkschreder
+.clang-tidy             @mkschreder
+/cmake/                 @mkschreder
 /CMakeLists.txt		@mkschreder
 /LICENSE		@mkschreder
 /README.md		@mkschreder

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -1,0 +1,19 @@
+find_program(
+  CLANG_TIDY_EXE
+  NAMES "clang-tidy"
+  DOC "Path to clang-tidy executable")
+
+if(NOT CLANG_TIDY_EXE)
+  message(FATAL_ERROR "clang-tidy not found")
+endif()
+
+function(clang_tidy_check TARGET)
+  # Only check header files from the same current source dir
+  get_filename_component(SOURCE_DIR_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
+  set(DO_CLANG_TIDY
+      "${CLANG_TIDY_EXE}" "-extra-arg=-ferror-limit=0"
+      "-p=${CMAKE_CURRENT_BUILD_DIR}/" "--header-filter=${SOURCE_DIR_NAME}/.*")
+
+  set_target_properties(${TARGET} PROPERTIES C_CLANG_TIDY "${DO_CLANG_TIDY}")
+  set_target_properties(${TARGET} PROPERTIES CXX_CLANG_TIDY "${DO_CLANG_TIDY}")
+endfunction()

--- a/cmake/configure_tidy.cmake
+++ b/cmake/configure_tidy.cmake
@@ -1,0 +1,6 @@
+function(configure_tidy TARGET_NAME)
+  if(SECONTROL_CLANG_TIDY)
+    include(clang-tidy)
+    clang_tidy_check(${TARGET_NAME})
+  endif()
+endfunction()

--- a/cmake/toolchain/clang.cmake
+++ b/cmake/toolchain/clang.cmake
@@ -1,0 +1,4 @@
+set(CMAKE_SYSTEM_NAME Linux)
+
+set(CMAKE_C_COMPILER "clang")
+set(CMAKE_CXX_COMPILER "clang++")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,3 +10,5 @@ add_library(control STATIC ${SOURCES})
 target_compile_options(control PRIVATE -Wall -Wextra -Werror -pedantic)
 
 target_include_directories(control PUBLIC "${CMAKE_SOURCE_DIR}/include")
+
+configure_tidy(control)


### PR DESCRIPTION
Closes #9

- Add build option for clang-tidy build
- Add clang-tidy executable finder
- Add clang-tidy utility function configure_tidy
- Add toolchain file for clang (mixing GCC or other compilers with
  clang-tidy is bound to break)
- Add initial .clang-tidy configuration
- Check target control using configure_tidy

Example configuration command:
```
$ cmake -G Ninja \
    -DCMAKE_TOOLCHAIN_FILE $SOURCE_DIR/cmake/toolchain/clang.cmake \
    -DSECONTROL_CLANG_TIDY=ON \
    $SOURCE_DIR
```