### PR TITLE
Add clang-tidy checks to ci

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -5,6 +5,8 @@
 --min-conf-desc-length=1
 --typedefsfile=scripts/checkpatch/typedefsfile
 
+--ignore LINE_SPACING
+--ignore DEEP_INDENTATION
 --ignore SPDX_LICENSE_TAG
 --ignore LEADING_SPACE
 --ignore CONSTANT_COMPARISON

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,22 +1,12 @@
 ---
-Checks:    "bugprone-*,\
-            cert-*,\
-            clang-analyzer-*,\
-            google-*,\
-            llvm-*,\
-            misc-*,\
-            modernize-*,\
-            performance-*,\
-            readability-*,\
-            -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,\
-            -google-readability-braces-around-statements,\
-            -google-readability-todo,\
-            -llvm-header-guard,\
-            -modernize-use-trailing-return-type,\
-            -readability-misleading-indentation"
+Checks:    'bugprone-*,cert-*,clang-analyzer-*,google-*,llvm-*,misc-*,modernize-*,performance-*,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-google-readability-braces-around-statements,-google-readability-todo,-llvm-header-guard,-modernize-use-trailing-return-type,-readability-misleading-indentation,-cert-msc30*,-cert-msc51*,-cert-msc32*,-cert-msc50*'
 WarningsAsErrors:   '*'
 AnalyzeTemporaryDtors: false
 CheckOptions:
+  - key:             cert-msc32-c.DisallowedSeedTypes
+    value:           ''
+  - key:             cert-msc51-cpp.DisallowedSeedTypes
+    value:           ''
   - key:             performance-move-const-arg.CheckTriviallyCopyableMove
     value:           0
   - key:             readability-identifier-naming.ClassCase
@@ -24,9 +14,9 @@ CheckOptions:
   - key:             readability-identifier-naming.ClassConstantCase
     value:           CamelCase
   - key:             readability-identifier-naming.ClassConstantPrefix
-    value:           'k'
+    value:           ''
   - key:             readability-identifier-naming.EnumCase
-    value:           CamelCase
+    value:           lower_case
   - key:             readability-identifier-naming.EnumConstantCase
     value:           UPPER_CASE
   - key:             readability-identifier-naming.FunctionCase
@@ -34,7 +24,7 @@ CheckOptions:
   - key:             readability-identifier-naming.GlobalConstantCase
     value:           UPPER_CASE
   - key:             readability-identifier-naming.GlobalConstantPrefix
-    value:           'G_'
+    value:           ''
   - key:             readability-identifier-naming.MemberCase
     value:           lower_case
   - key:             readability-identifier-naming.NamespaceCase
@@ -46,9 +36,5 @@ CheckOptions:
   - key:             readability-identifier-naming.ProtectedMemberSuffix
     value:           '_'
   - key:             readability-identifier-naming.MethodCase
-    value:           camelBack
-  - key:             readability-identifier-naming.ParameterCase
-    value:           lower_case
-  - key:             readability-identifier-naming.VariableCase
     value:           lower_case
 ...

--- a/cmake/configure_tidy.cmake
+++ b/cmake/configure_tidy.cmake
@@ -1,5 +1,5 @@
 function(configure_tidy TARGET_NAME)
-  if(SECONTROL_CLANG_TIDY)
+  if(CHECK_CLANG_TIDY)
     include(clang-tidy)
     clang_tidy_check(${TARGET_NAME})
   endif()

--- a/cmake/toolchain/clang.cmake
+++ b/cmake/toolchain/clang.cmake
@@ -1,4 +1,0 @@
-set(CMAKE_SYSTEM_NAME Linux)
-
-set(CMAKE_C_COMPILER "clang")
-set(CMAKE_CXX_COMPILER "clang++")

--- a/include/control/dynamics.h
+++ b/include/control/dynamics.h
@@ -15,10 +15,12 @@ struct pid {
 	float Kp, Ki, Kd, d;
 };
 
+enum pid_imc_mode { PID_IMC_AGGRESSIVE, PID_IMC_MODERATE, PID_IMC_CONSERVATIVE };
+
 void pid_init(struct pid *self);
 void pid_set_gains(struct pid *self, float Kp, float Ki, float Kd, float d);
 void pid_set_from_imc(struct pid *self, float aggr, float process_gain, float time_constant,
-		      float dead_time);
+		      float dead_time, enum pid_imc_mode mode);
 float pid_step(struct pid *self, float e);
 
 /**
@@ -35,10 +37,11 @@ float pid_step(struct pid *self, float e);
  * \param HORIZON Horizon
  * \param ITERATION_LIMIT Number of iterations
  * \param has_integration set to true is system has an integration behavior
+ * \retval 0 Success
+ * \retval -EINVAL Invalid arguments
  */
-void mpc(float A[], float B[], float C[], float x[], float u[], float r[], uint8_t ADIM,
-	 uint8_t YDIM, uint8_t RDIM, uint8_t HORIZON, uint8_t ITERATION_LIMIT,
-	 bool has_integration);
+int mpc(float A[], float B[], float C[], float x[], float u[], const float *const r, uint8_t ADIM,
+	uint8_t YDIM, uint8_t RDIM, uint8_t HORIZON, uint8_t ITERATION_LIMIT, bool has_integration);
 /**
  * \brief Linear kalman filter state update
  * \details
@@ -155,10 +158,13 @@ bool is_stable(const float *const A, uint8_t ADIM);
  * \brief Continuous to discrete transformation
  * \details
  *   Turn A and B into discrete form with given sample time
+ * \param Ad discrete output system A matrix [ADIM * ADIM]
+ * \param Bd discrete output system B matrix [ADIM * RDIM]
  * \param A System A matrix [ADIM * ADIM]
  * \param B System B matrix [ADIM * RDIM]
  * \param ADIM Size of system A matrix (rows and columns)
  * \param RDIM Number of rows in B matrix
  * \param sampleTime Sampling time
  **/
-void c2d(float *A, float *B, uint8_t ADIM, uint8_t RDIM, float sampleTime);
+void c2d(float *Ad, float *Bd, const float *const A, const float *const B, uint8_t ADIM,
+	 uint8_t RDIM, float sampleTime);

--- a/include/control/filter.h
+++ b/include/control/filter.h
@@ -25,5 +25,24 @@ void filtfilt(float *y_out, const float *const y, const float *const t, uint16_t
 void mcs_collect(float P[], uint16_t column_p, float x[], uint8_t row_x, float index_factor);
 void mcs_estimate(float P[], uint16_t column_p, float x[], uint8_t row_x);
 void mcs_clean(float P[], uint16_t column_p, uint8_t row_x);
-void sqr_ukf(float y[], float xhat[], float Rn[], float Rv[], float u[],
-	     void (*F)(float[], float[], float[]), float S[], float alpha, float beta, uint8_t L);
+/**
+ * \brief Square Root Unscented Kalman Filter
+ * \details For State Estimation (A better version than regular UKF)
+ * \param L Number of states, or sensors in practice.
+ * \param beta Used to incorporate prior knowledge of the distribution of x (for
+ *    Gaussian distributions, beta = 2 is optimal)
+ * \param alpha Determines the spread of the sigma points around xhat and alpha
+ *    is usually set to 0.01 <= alpha <= 1
+ * \param S [L * L] State estimate error covariance
+ * \param F F(float dx[L], float x[L], float u[L]) = Transition function
+ * \param x [L] State vector
+ * \param u [L] Input signal
+ * \param Rv [L * L] Process noise covariance matrix
+ * \param Rn [L * L] Measurement noise covariance matrix
+ * \param xhat [L] Estimated state (our input)
+ * \param y [L] Measurement state (our output)
+ * \retval 0 Success
+ * \retval -EINVAL Invalid parameters
+ **/
+int sqr_ukf(float y[], float xhat[], float Rn[], float Rv[], float u[],
+	    void (*F)(float[], float[], float[]), float S[], float alpha, float beta, uint8_t L);

--- a/include/control/sysid.h
+++ b/include/control/sysid.h
@@ -8,14 +8,78 @@
  */
 
 #pragma once
+
 #include <stdint.h>
 
-void rls(uint8_t NP, uint8_t NZ, uint8_t NZE, float theta[], float u, float y, uint8_t *count,
-	 float *past_e, float *past_y, float *past_u, float phi[], float P[], float Pq,
-	 float forgetting);
+/**
+ * \brief Recursive least square. We estimate A(q)y(t) = B(q) + C(q)e(t)
+ * \param NP Number of poles
+ * \param NZ Number of zeros
+ * \param NZE Number of zeros in error
+ * \param u Input vector
+ * \param y Output vector
+ * \param count Counter output
+ * \param past_e Previous error output (y - sum(phi .* theta))
+ * \param past_y Past y = -y
+ * \param past_u Past u = u
+ * \param theta [NP + NZ + NZE]
+ * \param P [(NP + NZ + NZE)*(NP + NZ + NZE)]
+ * \param phi [NP + NZ + NZE]
+ * \param Pq Pq > 0
+ * \param forgetting 0 < forgetting <= 1
+ * \retval 0 Success
+ * \retval -EINVAL Invalid arguments
+ **/
+int rls(unsigned int NP, unsigned int NZ, unsigned int NZE, float theta[], float u, float y,
+	uint8_t *count, float *past_e, float *past_y, float *past_u, float phi[], float P[],
+	float Pq, float forgetting);
+/**
+ * \brief Observer kalman filter identification.
+ * \details
+ * This is the basic version, e.g it won't give you the kalman gain K matrix.
+ * If you need fully version, then look for MataveID at GitHub
+ * First collect your inputs u and outputs y and create impulse response g,
+ * called Markov parameters.  Then you must use era.c algorithm to convert
+ * impulse response g into a linear state space model.  Data length need to be
+ * the same as the column length n!
+ * \param row Number of rows in input
+ * \param column Number of columns in input
+ * \param u [m*n]
+ * \param y [m*n]
+ * \param g [m*n] Markov parameters
+ **/
 void okid(float u[], float y[], float g[], uint16_t row, uint16_t column);
-void era(float u[], float y[], uint16_t row, uint16_t column, float A[], float B[], float C[],
-	 uint8_t row_a, uint8_t inputs_outputs);
-void sqr_ukf_id(float d[], float what[], float Re[], float x[],
-		void (*G)(float[], float[], float[]), float lambda_rls, float Sw[], float alpha,
-		float beta, uint8_t L);
+/**
+ * \brief Eigensystem Realization Algorithm.
+ * \param u [m*n] // Input signal
+ * \param y [m*n] // Output signal
+ * \param row Rows in input signal
+ * \param column Columns in input signal
+ * \param row_a Rows in A
+ * \param A [ADIM*ADIM] // System matrix with dimension ADIM*ADIM
+ * \param B [ADIM*inputs_outputs] // Input matrix with dimension ADIM*inputs_outputs
+ * \param C [inputs_outputs*ADIM] // Output matrix with dimension inputs_outputs*ADMIN
+ * \param inputs_outputs number of inputs and outputs
+ * \retval 0 Success
+ * \retval -EINVAL Invalid parameters
+ **/
+int era(float u[], float y[], uint16_t row, uint16_t column, float A[], float B[], float C[],
+	uint8_t row_a, uint8_t inputs_outputs);
+/**
+ * \brief Square Root Unscented Kalman Filter
+ * \details For Parameter Estimation (A better version than regular UKF)
+ * \param L Number of states, or sensors in practice.
+ * \param beta used to incorporate prior knowledge of the distribution of x (for
+ *    Gaussian distributions, beta = 2 is optimal)
+ * \param alpha determines the spread of the sigma points around what and alpha
+ *    is usually set to 0.01 <= alpha <= 1
+ * \param Sw [L * L] Parameter estimate error covariance
+ * \param lambda_rls Scalar factor 0 <= lambda_rls <= 1. A good number is close to 1 like 0.995
+ * \param G G(float dw[L], float x[L], float w[L]) = Transition function with unknown parameters
+ * \param x [L] State vector
+ * \param Re [L * L] Measurement noise covariance matrix
+ * \param what [L] Estimated parameter (our input)
+ * \param d [L] Measurement parameter (our output)
+ **/
+int sqr_ukf_id(float d[], float what[], float Re[], float x[], void (*G)(float[], float[], float[]),
+	       float lambda_rls, float Sw[], float alpha, float beta, uint8_t L);

--- a/scripts/build
+++ b/scripts/build
@@ -6,13 +6,18 @@
 
 [[ -d build ]] && rm -rf build
 
+set -e
+
 mkdir -p build
 cd build
-cmake ..
+cmake \
+	-DCHECK_CLANG_TIDY=ON \
+	..
 make -j8
 make docs | grep "warning:" && {
 	echo "There were documentation errors"
 	echo "Rerun 'make docs' again and check it"
+	exit 1
 }
 cpack
 cd ..

--- a/scripts/init
+++ b/scripts/init
@@ -4,5 +4,5 @@
 # Consulting: https://swedishembedded.com/go
 # Training: https://swedishembedded.com/tag/training
 
-apt update &&
-apt install -qy libgtest-dev
+apt-get update &&
+  apt-get install -qy libgtest-dev clang-tidy

--- a/src/ai/a_star.c
+++ b/src/ai/a_star.c
@@ -7,10 +7,11 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/ai.h"
+
 #include <math.h>
-#include <string.h>
 #include <stdlib.h>
-#include <control/ai.h>
+#include <string.h>
 
 static void heuristic_map(int *map, int x_stop, int y_stop, int height, int width,
 			  uint8_t norm_mode);
@@ -42,9 +43,10 @@ void a_star(const int *const map_in, int path_x[], int path_y[], int x_start, in
 
 	for (int k = 0; k < height * width; k++) {
 		// Look to the left, right, up and down
-		for (int index = 0; index < 4; index++)
+		for (int index = 0; index < 4; index++) {
 			direction[index] =
 				map[(y + y_directions[index]) * width + x + x_directions[index]];
+		}
 
 		// Take the decision where to go by looking at direction array
 		minValue = direction[0];
@@ -70,14 +72,18 @@ void a_star(const int *const map_in, int path_x[], int path_y[], int x_start, in
 		path_y[k] = y;
 
 		// Where to go - position variable tells
-		if (position == 0)
+		if (position == 0) {
 			x--; // Go one step left
-		if (position == 1)
+		}
+		if (position == 1) {
 			x++; // Go one step right
-		if (position == 2)
+		}
+		if (position == 2) {
 			y--; // Go one step up
-		if (position == 3)
+		}
+		if (position == 3) {
 			y++; // Go one step down
+		}
 
 		// Check if we are at our goal
 		if (*(map + y * width + x) == 0) {
@@ -141,8 +147,9 @@ void a_star(const int *const map_in, int path_x[], int path_y[], int x_start, in
 					    y + y_directions[index] == path_y[j]) {
 						// We want to have the largest "gap",
 						// which is the zigzag
-						if (j > position)
+						if (j > position) {
 							position = j;
+						}
 					}
 				}
 				// If we got zigzag.
@@ -201,11 +208,13 @@ static void heuristic_map(int map[], int x_stop, int y_stop, int height, int wid
 				int dy = (y_stop + i) - (j + i);
 
 				// L1-Norm
-				if (norm_mode == 1)
+				if (norm_mode == 1) {
 					map[j * width + i] = abs(dx) + abs(dy);
+				}
 				// L2-Norm (without square root, not needed due to integers)
-				if (norm_mode == 2)
+				if (norm_mode == 2) {
 					map[j * width + i] = dx * dx + dy * dy;
+				}
 				// You can add more heuristic here!
 			}
 		}

--- a/src/ai/inpolygon.c
+++ b/src/ai/inpolygon.c
@@ -7,9 +7,10 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <math.h>
 #include "control/ai.h"
 #include "control/misc.h"
+
+#include <math.h>
 
 uint8_t inpolygon(float x, float y, const float *const px, const float *const py, uint8_t p)
 {

--- a/src/dynamics/c2d.c
+++ b/src/dynamics/c2d.c
@@ -7,11 +7,13 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <string.h>
 #include "control/linalg.h"
 #include "control/dynamics.h"
 
-void c2d(float A[], float B[], uint8_t ADIM, uint8_t RDIM, float sampleTime)
+#include <string.h>
+
+void c2d(float *Ad, float *Bd, const float *const A, const float *const B, uint8_t ADIM,
+	 uint8_t RDIM, float sampleTime)
 {
 	float M[(ADIM + RDIM) * (ADIM + RDIM)];
 
@@ -28,14 +30,15 @@ void c2d(float A[], float B[], uint8_t ADIM, uint8_t RDIM, float sampleTime)
 		}
 	}
 	expm(M, M, ADIM + RDIM);
+	// copy back the matrices
 	for (uint8_t i = 0; i < ADIM; i++) {
 		// For A row
 		for (uint8_t j = 0; j < ADIM; j++) {
-			A[i * ADIM + j] = M[i * (ADIM + RDIM) + j];
+			Ad[i * ADIM + j] = M[i * (ADIM + RDIM) + j];
 		}
 		// For B row
 		for (uint8_t j = 0; j < RDIM; j++) {
-			B[i * RDIM + j] = M[i * (ADIM + RDIM) + j + ADIM];
+			Bd[i * RDIM + j] = M[i * (ADIM + RDIM) + j + ADIM];
 		}
 	}
 }

--- a/src/dynamics/mrac.c
+++ b/src/dynamics/mrac.c
@@ -8,12 +8,30 @@
  */
 
 #include "control/linalg.h"
-#include "control/misc.h"
 #include "control/dynamics.h"
+#include "control/misc.h"
 
-static void integral(float I[], float gain, float x[], float e[], uint8_t RDIM);
-static void modelerror(float e[], float y[], float r[], uint8_t RDIM);
-static void findinput(float u[], float r[], float I1[], float y[], float I2[], uint8_t RDIM);
+static void integral(float *I, float gain, const float *const x, const float *const e, uint8_t RDIM)
+{
+	for (uint8_t i = 0; i < RDIM; i++) {
+		I[i] += gain * x[i] * e[i];
+	}
+}
+
+static void modelerror(float *e, const float *const y, const float *const r, uint8_t RDIM)
+{
+	for (uint8_t i = 0; i < RDIM; i++) {
+		e[i] = y[i] - r[i];
+	}
+}
+
+static void findinput(float *u, const float *const r, const float *const I1, const float *const y,
+		      const float *const I2, uint8_t RDIM)
+{
+	for (uint8_t i = 0; i < RDIM; i++) {
+		u[i] = r[i] * I1[i] - y[i] * I2[i];
+	}
+}
 
 void mrac(float limit, float gain, float y[], float u[], float r[], float I1[], float I2[],
 	  uint8_t RDIM)
@@ -33,22 +51,4 @@ void mrac(float limit, float gain, float y[], float u[], float r[], float I1[], 
 
 	// Find input signal
 	findinput(u, r, I1, y, I2, RDIM);
-}
-
-static void integral(float I[], float gain, float x[], float e[], uint8_t RDIM)
-{
-	for (uint8_t i = 0; i < RDIM; i++)
-		I[i] += gain * x[i] * e[i];
-}
-
-static void modelerror(float e[], float y[], float r[], uint8_t RDIM)
-{
-	for (uint8_t i = 0; i < RDIM; i++)
-		e[i] = y[i] - r[i];
-}
-
-static void findinput(float u[], float r[], float I1[], float y[], float I2[], uint8_t RDIM)
-{
-	for (uint8_t i = 0; i < RDIM; i++)
-		u[i] = r[i] * I1[i] - y[i] * I2[i];
 }

--- a/src/dynamics/pid.c
+++ b/src/dynamics/pid.c
@@ -5,10 +5,10 @@
  * Training: https://swedishembedded.com/tag/training
  */
 
-#include <string.h>
-#include <math.h>
-
 #include "control/dynamics.h"
+
+#include <math.h>
+#include <string.h>
 
 void pid_init(struct pid *self)
 {
@@ -16,13 +16,26 @@ void pid_init(struct pid *self)
 }
 
 void pid_set_from_imc(struct pid *self, float aggr, float process_gain, float time_constant,
-		      float dead_time)
+		      float dead_time, enum pid_imc_mode mode)
 {
-	float tc = fmaxf((0.1 * aggr) * time_constant, (0.8 * aggr) * dead_time);
-	float kc =
-		(1.0 / process_gain) * ((time_constant + 0.5 * dead_time) / (tc + 0.5 * dead_time));
-	float ti = time_constant + 0.5 * dead_time;
-	float td = (time_constant * dead_time) / (2.0 * time_constant + dead_time);
+	float tc = 0;
+
+	switch (mode) {
+	case PID_IMC_AGGRESSIVE:
+		tc = fmaxf((0.1F * aggr) * time_constant, (0.8F * aggr) * dead_time);
+		break;
+	case PID_IMC_MODERATE:
+		tc = fmaxf((1.0F * aggr) * time_constant, (8.0F * aggr) * dead_time);
+		break;
+	case PID_IMC_CONSERVATIVE:
+		tc = fmaxf((10.0F * aggr) * time_constant, (80.0F * aggr) * dead_time);
+		break;
+	}
+
+	float kc = (1.0F / process_gain) *
+		   ((time_constant + 0.5F * dead_time) / (tc + 0.5F * dead_time));
+	float ti = time_constant + 0.5F * dead_time;
+	float td = (time_constant * dead_time) / (2.0F * time_constant + dead_time);
 
 	self->Kp = kc;
 	self->Ki = kc / ti;

--- a/src/dynamics/stability.c
+++ b/src/dynamics/stability.c
@@ -7,9 +7,10 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <math.h>
 #include "control/linalg.h"
 #include "control/dynamics.h"
+
+#include <math.h>
 
 bool is_stable(const float *const A, uint8_t ADIM)
 {

--- a/src/dynamics/theta2ss.c
+++ b/src/dynamics/theta2ss.c
@@ -7,8 +7,9 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <string.h>
 #include "control/dynamics.h"
+
+#include <string.h>
 
 void theta2ss(float *A, float *B, float *C, float *K, const float *const theta, uint8_t ADIM,
 	      uint8_t NP, uint8_t NZ, uint8_t NZE, bool integral_action)

--- a/src/filter/filtfilt.c
+++ b/src/filter/filtfilt.c
@@ -7,9 +7,10 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/filter.h"
+
 #include <stdint.h>
 #include <string.h>
-#include "control/filter.h"
 
 // Euler method for simple ODE - Low pass filter
 static void simulation(float K, float *y, const float *const t, uint16_t l)

--- a/src/linalg/add.c
+++ b/src/linalg/add.c
@@ -7,8 +7,9 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
 #include <string.h>
-#include <control/linalg.h>
 
 /*
  * C = A + B

--- a/src/linalg/balance.c
+++ b/src/linalg/balance.c
@@ -7,8 +7,9 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
 #include <math.h>
-#include <control/linalg.h>
 
 /*
  * Balance a real matrix
@@ -19,32 +20,32 @@ void balance(float A[], uint16_t row)
 	uint16_t i, j, last = 0;
 	float s, r, g, f, c, sqrdx;
 
-	sqrdx = 4.0;
+	sqrdx = 4.0f;
 	while (last == 0) {
 		last = 1;
 		for (i = 0; i < row; i++) {
-			r = c = 0.0;
+			r = c = 0.0f;
 			for (j = 0; j < row; j++)
 				if (j != i) {
 					c += fabsf(*(A + row * j + i));
 					r += fabsf(*(A + row * i + j));
 				}
 			if (c != 0.0 && r != 0.0) {
-				g = r / 2.0;
-				f = 1.0;
+				g = r / 2.0f;
+				f = 1.0f;
 				s = c + r;
 				while (c < g) {
-					f *= 2.0;
+					f *= 2.0f;
 					c *= sqrdx;
 				}
-				g = r * 2.0;
+				g = r * 2.0f;
 				while (c > g) {
-					f /= 2.0;
+					f /= 2.0f;
 					c /= sqrdx;
 				}
-				if ((c + r) / f < 0.95 * s) {
+				if ((c + r) / f < 0.95f * s) {
 					last = 0;
-					g = 1.0 / f;
+					g = 1.0f / f;
 					for (j = 0; j < row; j++)
 						*(A + row * i + j) *= g;
 					for (j = 0; j < row; j++)

--- a/src/linalg/chol.c
+++ b/src/linalg/chol.c
@@ -7,10 +7,11 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <string.h>
-#include <math.h>
+#include "control/linalg.h"
+
 #include <float.h>
-#include <control/linalg.h>
+#include <math.h>
+#include <string.h>
 
 /*
  * Create A = L*L^T
@@ -36,6 +37,6 @@ void chol(const float *const A, float *L, uint16_t row)
 				L[row * j + j] = FLT_EPSILON; // Same as eps command in MATLAB
 			}
 			L[row * i + j] = (i == j) ? sqrtf(A[row * i + i] - s) :
-						    (1.0 / L[row * j + j] * (A[row * i + j] - s));
+						    (1.0f / L[row * j + j] * (A[row * i + j] - s));
 		}
 }

--- a/src/linalg/cholupdate.c
+++ b/src/linalg/cholupdate.c
@@ -7,9 +7,10 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
 #include <math.h>
 #include <string.h>
-#include <control/linalg.h>
 
 /*
  * Create L = cholupdate(L, x, rank_one_update)
@@ -20,14 +21,14 @@
  */
 void cholupdate(float *L, const float *const xx, uint16_t row, bool rank_one_update)
 {
-	float alpha = 0.0, beta = 1.0, beta2 = 0.0, gamma = 0.0, delta = 0.0;
+	float alpha = 0.0f, beta = 1.0f, beta2 = 0.0f, gamma = 0.0f, delta = 0.0f;
 	float x[row];
 
 	memcpy(x, xx, sizeof(x));
 
 	tran(L, L, row, row);
 
-	for (uint8_t i = 0; i < row; i++) {
+	for (int i = 0; i < row; i++) {
 		alpha = x[i] / L[row * i + i];
 		beta2 = rank_one_update == true ? sqrtf(beta * beta + alpha * alpha) :
 						  sqrtf(beta * beta - alpha * alpha);
@@ -40,11 +41,11 @@ void cholupdate(float *L, const float *const xx, uint16_t row, bool rank_one_upd
 
 			if (i < row) {
 				// line 34 in tripfield chol_updown function
-				for (uint8_t k = i + 1; k < row; k++)
+				for (int k = i + 1; k < row; k++)
 					x[k] -= alpha * L[row * k + i];
 
 				// line 35 in tripfield chol_updown function
-				for (uint8_t k = i + 1; k < row; k++)
+				for (int k = i + 1; k < row; k++)
 					L[row * k + i] = delta * L[row * k + i] + gamma * x[k];
 			}
 			x[i] = alpha;
@@ -55,11 +56,13 @@ void cholupdate(float *L, const float *const xx, uint16_t row, bool rank_one_upd
 			L[row * i + i] = delta * L[row * i + i];
 
 			if (i < row) {
-				for (uint8_t k = i + 1; k < row; k++)
+				for (int k = i + 1; k < row; k++) {
 					x[k] -= alpha * L[row * k + i];
+				}
 
-				for (uint8_t k = i + 1; k < row; k++)
+				for (int k = i + 1; k < row; k++) {
 					L[row * k + i] = delta * L[row * k + i] + gamma * x[k];
+				}
 			}
 			x[i] = alpha;
 			beta = beta2;

--- a/src/linalg/det.c
+++ b/src/linalg/det.c
@@ -17,7 +17,7 @@
  */
 float det(const float *const A, uint16_t row)
 {
-	float determinant = 1.0;
+	float determinant = 1.0f;
 	float LU[row * row];
 	uint8_t P[row];
 

--- a/src/linalg/dlyap.c
+++ b/src/linalg/dlyap.c
@@ -7,9 +7,10 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+#include "control/misc.h"
+
 #include <string.h>
-#include <control/misc.h>
-#include <control/linalg.h>
 
 /*
  * Discrete Lyapunov equation

--- a/src/linalg/expm.c
+++ b/src/linalg/expm.c
@@ -7,8 +7,9 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
 #include <string.h>
-#include <control/linalg.h>
 
 /*
  * Find matrix exponential, return A as A = expm(A)
@@ -41,7 +42,7 @@ void expm(const float *const A, float *exp, uint16_t row)
 		// F = A*F/k (we are borrowing T)
 		mul(T, A, F, row, row, row, row);
 		for (uint16_t i = 0; i < row * row; i++) {
-			F[i] = T[i] / k;
+			F[i] = T[i] / (float)k;
 		}
 		// T = E + F - E ( This is faster than T = F)
 		for (uint16_t i = 0; i < row * row; i++) {

--- a/src/linalg/hankel.c
+++ b/src/linalg/hankel.c
@@ -7,9 +7,10 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <string.h>
+#include "control/linalg.h"
+
 #include <errno.h>
-#include <control/linalg.h>
+#include <string.h>
 
 /*
  * Create hankel matrix of vector V. Step is just the shift. Normaly set this to 0.

--- a/src/linalg/inv.c
+++ b/src/linalg/inv.c
@@ -7,32 +7,36 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <math.h>
-#include <float.h>
-#include <string.h>
+#include "control/linalg.h"
+
 #include <errno.h>
-#include <control/linalg.h>
+#include <float.h>
+#include <math.h>
+#include <string.h>
 
 static int solve(const float *const LU, float *x, float *b, uint8_t *P, uint16_t row)
 {
 	// forward substitution with pivoting
-	for (uint16_t i = 0; i < row; ++i) {
+	for (int i = 0; i < row; ++i) {
 		x[i] = b[P[i]];
 
-		for (uint16_t j = 0; j < i; ++j)
+		for (int j = 0; j < i; ++j) {
 			x[i] = x[i] - LU[row * P[i] + j] * x[j];
+		}
 	}
 
 	// backward substitution with pivoting
-	for (int16_t i = row - 1; i >= 0; --i) {
-		for (int16_t j = i + 1; j < row; ++j)
+	for (int i = row - 1; i >= 0; --i) {
+		for (int j = i + 1; j < row; ++j) {
 			x[i] = x[i] - LU[row * P[i] + j] * x[j];
+		}
 
 		// Just in case if we divide with zero
-		if (fabsf(LU[row * P[i] + i]) > FLT_EPSILON)
+		if (fabsf(LU[row * P[i] + i]) > FLT_EPSILON) {
 			x[i] = x[i] / LU[row * P[i] + i];
-		else
+		} else {
 			return -ENOTSUP;
+		}
 	}
 
 	return 0;
@@ -57,8 +61,9 @@ int inv(float *Ai_out, const float *const A, uint16_t row)
 	// Create the inverse
 	for (uint16_t i = 0; i < row; i++) {
 		tmpvec[i] = 1.0f;
-		if (solve(LU, &Ai[row * i], tmpvec, P, row) != 0)
+		if (solve(LU, &Ai[row * i], tmpvec, P, row) != 0) {
 			return -ENOTSUP; // We divided with zero
+		}
 		tmpvec[i] = 0.0f;
 	}
 

--- a/src/linalg/linsolve_chol.c
+++ b/src/linalg/linsolve_chol.c
@@ -7,7 +7,8 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <control/linalg.h>
+#include "control/linalg.h"
+
 void linsolve_chol(const float *const A, float *x, const float *const b, uint16_t row)
 {
 	float L[row * row];

--- a/src/linalg/linsolve_gauss.c
+++ b/src/linalg/linsolve_gauss.c
@@ -7,8 +7,9 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
 #include <string.h>
-#include <control/linalg.h>
 
 /*
  * Prepare A and b into upper triangular with triu.
@@ -19,7 +20,7 @@
 static void triu(float *A, float *b, uint16_t row)
 {
 	// Make A to upper triangular. Also change b as well.
-	float pivot = 0.0;
+	float pivot = 0.0f;
 
 	// Column
 	for (uint16_t j = 0; j < row; j++) {

--- a/src/linalg/linsolve_lower_triangular.c
+++ b/src/linalg/linsolve_lower_triangular.c
@@ -7,8 +7,9 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
 #include <string.h>
-#include <control/linalg.h>
 
 /*
  * Solve with forward substitution. This can be used with Cholesky decomposition
@@ -21,12 +22,13 @@ void linsolve_lower_triangular(const float *const A, float x[], const float *con
 {
 	// Time to solve x from Ax = b.
 	memset(x, 0, row * sizeof(float));
-	float sum;
 
 	for (uint16_t i = 0; i < row; i++) {
-		sum = 0;
-		for (uint16_t j = 0; j < i; j++)
+		float sum = 0;
+
+		for (uint16_t j = 0; j < i; j++) {
 			sum = sum + A[row * i + j] * x[j];
+		}
 
 		x[i] = (b[i] - sum) / A[row * i + i];
 	}

--- a/src/linalg/linsolve_lup.c
+++ b/src/linalg/linsolve_lup.c
@@ -21,23 +21,25 @@ int linsolve_lup(const float *const A, float *x, const float *const b, uint16_t 
 	}
 
 	// forward substitution with pivoting
-	for (uint16_t i = 0; i < row; ++i) {
+	for (int i = 0; i < row; ++i) {
 		x[i] = b[P[i]];
 
-		for (uint16_t j = 0; j < i; ++j)
+		for (int j = 0; j < i; ++j) {
 			x[i] = x[i] - LU[row * P[i] + j] * x[j];
+		}
 	}
 
 	// backward substitution with pivoting
-	for (int16_t i = row - 1; i >= 0; --i) {
-		for (int16_t j = i + 1; j < row; ++j)
+	for (int i = row - 1; i >= 0; --i) {
+		for (int j = i + 1; j < row; ++j) {
 			x[i] = x[i] - LU[row * P[i] + j] * x[j];
+		}
 
 		x[i] = x[i] / LU[row * P[i] + i];
 
-		// Important because when i = -1, then i will become 65535
-		if (i == 0)
+		if (i == 0) {
 			break;
+		}
 	}
 
 	return 0;

--- a/src/linalg/linsolve_upper_triangular.c
+++ b/src/linalg/linsolve_upper_triangular.c
@@ -7,8 +7,9 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
 #include <string.h>
-#include <control/linalg.h>
 
 /*
  * This solves Ax = b.
@@ -22,20 +23,19 @@ void linsolve_upper_triangular(const float *const A, float x[], const float *con
 {
 	// Time to solve x from Ax = b.
 	memset(x, 0, column * sizeof(float));
-	float sum;
 
 	// Column
-	for (int16_t i = column - 1; i >= 0; i--) {
-		sum = 0.0; // This is our sum
+	for (int i = column - 1; i >= 0; i--) {
+		float sum = 0.0f; // This is our sum
 		// Row
-		for (int16_t j = i; j < column; j++) {
+		for (int j = i; j < column; j++) {
 			sum += A[i * column + j] * x[j];
 		}
 		x[i] = (b[i] - sum) / A[i * column + i];
 
-		// For backwards unsigned for-loops, important because uint16 i = -1 is actually 65535
-		if (i == 0)
+		if (i == 0) {
 			break;
+		}
 	}
 }
 

--- a/src/linalg/lup.c
+++ b/src/linalg/lup.c
@@ -7,32 +7,33 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <string.h>
+#include "control/linalg.h"
+
 #include <errno.h>
-#include <math.h>
 #include <float.h>
-#include <control/linalg.h>
+#include <math.h>
+#include <string.h>
 
 int lup(const float *const A, float *LU, uint8_t *P, uint16_t row)
 {
-	// Variables
-	uint16_t ind_max, tmp_int;
-
 	// If not the same
 	if (A != LU)
 		memcpy(LU, A, row * row * sizeof(float));
 
 	// Create the pivot vector
-	for (uint16_t i = 0; i < row; ++i)
+	for (uint16_t i = 0; i < row; ++i) {
 		P[i] = i;
+	}
 
 	for (uint16_t i = 0; i < row - 1; ++i) {
-		ind_max = i;
+		uint16_t ind_max = i;
+
 		for (uint16_t j = i + 1; j < row; ++j)
 			if (fabsf(LU[row * P[j] + i]) > fabsf(LU[row * P[ind_max] + i]))
 				ind_max = j;
 
-		tmp_int = P[i];
+		uint16_t tmp_int = P[i];
+
 		P[i] = P[ind_max];
 		P[ind_max] = tmp_int;
 

--- a/src/linalg/mul.c
+++ b/src/linalg/mul.c
@@ -7,8 +7,9 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
 #include <errno.h>
-#include <control/linalg.h>
 
 int mul(float *C, const float *const A, const float *const B, uint16_t row_a, uint16_t column_a,
 	uint16_t row_b, uint16_t column_b)

--- a/src/linalg/norm.c
+++ b/src/linalg/norm.c
@@ -7,9 +7,10 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
 #include <math.h>
 #include <string.h>
-#include <control/linalg.h>
 
 float norm(const float *const Ain, uint16_t row, uint16_t column, uint8_t l)
 {

--- a/src/linalg/pinv.c
+++ b/src/linalg/pinv.c
@@ -7,7 +7,7 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <control/linalg.h>
+#include "control/linalg.h"
 
 void pinv(float *Ai, const float *const A, uint16_t row, uint16_t column)
 {
@@ -22,16 +22,21 @@ void pinv(float *Ai, const float *const A, uint16_t row, uint16_t column)
 		svd_golub_reinsch(A, row, column, U, S, V);
 
 	// Do inv(S)
-	for (uint16_t i = 0; i < column; i++)
-		S[i] = 1.0 / S[i]; // Create inverse diagonal matrix
+	for (uint16_t i = 0; i < column; i++) {
+		// Create inverse diagonal matrix
+		// TODO: can this ever result in div by zero?
+		S[i] = 1.0f / S[i];
+	}
 
 	// Transpose U'
 	tran(U, U, row, column);
 
 	// U = S*U'
-	for (uint16_t i = 0; i < row; i++)
-		for (uint16_t j = 0; j < column; j++)
+	for (uint16_t i = 0; i < row; i++) {
+		for (uint16_t j = 0; j < column; j++) {
 			U[row * j + i] = S[j] * U[row * j + i];
+		}
+	}
 
 	// Do pinv now: A = V*U
 	mul(Ai, V, U, column, column, column, row);

--- a/src/linalg/qr.c
+++ b/src/linalg/qr.c
@@ -7,11 +7,11 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
+#include <errno.h>
 #include <math.h>
 #include <string.h>
-#include <errno.h>
-
-#include <control/linalg.h>
 
 int qr(const float *const A, float *Q, float *R, uint16_t row_a, uint16_t column_a,
        bool only_compute_R)

--- a/src/linalg/sum.c
+++ b/src/linalg/sum.c
@@ -7,8 +7,9 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
 #include <string.h>
-#include <control/linalg.h>
 
 void sum(float *Ar, const float *const A, uint16_t row, uint16_t column, uint8_t l)
 {

--- a/src/linalg/tran.c
+++ b/src/linalg/tran.c
@@ -7,17 +7,18 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+
 #include <string.h>
-#include <control/linalg.h>
 
 void tran(float *At, const float *const A, uint16_t row, uint16_t column)
 {
 	float B[row * column];
-	float *transpose;
 	const float *ptr_A = A;
 
 	for (uint16_t i = 0; i < row; i++) {
-		transpose = &B[i];
+		float *transpose = &B[i];
+
 		for (uint16_t j = 0; j < column; j++) {
 			*transpose = *ptr_A;
 			ptr_A++;

--- a/src/misc/cat.c
+++ b/src/misc/cat.c
@@ -7,9 +7,10 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/misc.h"
+
 #include <assert.h>
 #include <string.h>
-#include <control/misc.h>
 
 void cat(float *C, const float *const A, const float *const B, int vertical, uint16_t row_a,
 	 uint16_t column_a, uint16_t row_b, uint16_t column_b, uint16_t row_c, uint16_t column_c)

--- a/src/misc/cut.c
+++ b/src/misc/cut.c
@@ -7,7 +7,8 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <control/misc.h>
+#include "control/misc.h"
+
 #include <string.h>
 
 void cut(float *B, const float *const A, uint16_t row, uint16_t column, uint16_t start_row,

--- a/src/misc/insert.c
+++ b/src/misc/insert.c
@@ -8,6 +8,7 @@
  */
 
 #include "control/misc.h"
+
 #include <string.h>
 
 void insert(float *B, const float *const A, uint16_t row_a, uint16_t column_a, uint16_t column_b,

--- a/src/misc/print.c
+++ b/src/misc/print.c
@@ -7,7 +7,8 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <control/misc.h>
+#include "control/misc.h"
+
 #include <stdio.h>
 
 /*

--- a/src/misc/randn.c
+++ b/src/misc/randn.c
@@ -7,12 +7,12 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/misc.h"
+
+#include <math.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <time.h>
-#include <math.h>
-
-#include "control/misc.h"
 
 static float generate_gauss(float mu, float sigma)
 {
@@ -22,23 +22,24 @@ static float generate_gauss(float mu, float sigma)
 
 	if (call == 1) {
 		call = !call;
-		return (mu + sigma * (float)X2);
+		return (mu + sigma * X2);
 	}
 
 	// Compute the uniform norm
 	do {
-		U1 = -1 + ((float)rand() / RAND_MAX) * 2;
-		U2 = -1 + ((float)rand() / RAND_MAX) * 2;
-		W = pow(U1, 2) + pow(U2, 2);
-	} while (W >= 1 || W == 0);
+		U1 = -1.0f + ((float)rand() / (float)RAND_MAX) * 2.0f;
+		U2 = -1.0f + ((float)rand() / (float)RAND_MAX) * 2.0f;
+		W = powf(U1, 2) + powf(U2, 2);
+	} while (W >= 1.0f || W == 0.0f);
 
-	scalar = sqrt((-2 * log(W)) / W);
+	// TODO: potential division by zero
+	scalar = sqrtf((-2.0f * logf(W)) / W);
 	X1 = U1 * scalar;
 	X2 = U2 * scalar;
 
 	call = !call;
 
-	return (mu + sigma * (float)X1);
+	return (mu + sigma * X1);
 }
 
 void randn(float *x, uint16_t length, float mu, float sigma)

--- a/src/misc/stddev.c
+++ b/src/misc/stddev.c
@@ -7,8 +7,9 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/misc.h"
+
 #include <math.h>
-#include <control/misc.h>
 
 /*
  * Compute Standard deviation
@@ -20,8 +21,9 @@ float stddev(const float *const x, uint16_t length)
 	float mu = mean(x, length);
 	float sigma = 0;
 
-	for (uint16_t i = 0; i < length; i++)
+	for (uint16_t i = 0; i < length; i++) {
 		sigma += (x[i] - mu) * (x[i] - mu);
+	}
 
 	return sqrtf(sigma / ((float)length - 1));
 }

--- a/src/model/dc_motor.c
+++ b/src/model/dc_motor.c
@@ -4,24 +4,27 @@
  * Consulting: https://swedishembedded.com/go
  * Training: https://swedishembedded.com/tag/training
  **/
+
+#include "control/linalg.h"
+#include "control/model/dc_motor.h"
+
 #undef __STRICT_ANSI__
+
 #include <math.h>
 #include <string.h>
-#include <control/linalg.h>
-#include <control/model/dc_motor.h>
 
 void model_dc_motor_init(struct model_dc_motor *self)
 {
 	memset(self, 0, sizeof(*self));
-	self->u[0] = 0;
-	self->J = 0.01;
-	self->b = 0.1;
-	self->K = 0.01;
-	self->R = 1;
-	self->L = 0.5;
-	self->Ts = 0.1;
-	self->limits.voltage = 24;
-	self->limits.current = 10;
+	self->u[0] = 0.0f;
+	self->J = 0.01f;
+	self->b = 0.1f;
+	self->K = 0.01f;
+	self->R = 1.0f;
+	self->L = 0.5f;
+	self->Ts = 0.1f;
+	self->limits.voltage = 24.0f;
+	self->limits.current = 10.0f;
 }
 
 void model_dc_motor_step(struct model_dc_motor *self)
@@ -34,10 +37,12 @@ void model_dc_motor_step(struct model_dc_motor *self)
 	const float Ts = self->Ts;
 
 	// apply limits
-	if (self->u[0] < -self->limits.voltage)
+	if (self->u[0] < -self->limits.voltage) {
 		self->u[0] = -self->limits.voltage;
-	if (self->u[0] > self->limits.voltage)
+	}
+	if (self->u[0] > self->limits.voltage) {
 		self->u[0] = self->limits.voltage;
+	}
 
 	self->A[0 * 2 + 0] =
 		J * (L + R * Ts) / (powf(K, 2) * powf(Ts, 2) + (J + Ts * b) * (L + R * Ts));
@@ -69,10 +74,11 @@ void model_dc_motor_step(struct model_dc_motor *self)
 	self->y[0] = Cx[0] + Du[0];
 	// integrate rotor angle
 	self->position += self->x[0] * Ts;
-	self->position = fmodf(self->position + M_PI, 2 * M_PI);
-	if (self->position < 0)
-		self->position += 2 * M_PI;
-	self->position = self->position - M_PI;
+	self->position = fmodf(self->position + (float)M_PI, 2.0f * (float)M_PI);
+	if (self->position < 0) {
+		self->position += 2.0f * (float)M_PI;
+	}
+	self->position -= (float)M_PI;
 }
 
 float model_dc_motor_get_omega(struct model_dc_motor *self)

--- a/src/optimization/linprog.c
+++ b/src/optimization/linprog.c
@@ -7,12 +7,12 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <string.h>
-#include <math.h>
-#include <float.h>
+#include "control/optimization.h"
+#include "control/linalg.h"
 
-#include <control/optimization.h>
-#include <control/linalg.h>
+#include <float.h>
+#include <math.h>
+#include <string.h>
 
 static void opti(float c[], float A[], float b[], float x[], uint8_t row_a, uint8_t column_a,
 		 uint8_t max_or_min, uint8_t iteration_limit);
@@ -103,22 +103,22 @@ static void opti(float c[], float A[], float b[], float x[], uint8_t row_a, uint
 	// Done!
 
 	// Do row operations
-	float entry = 0.0;
+	float entry = 0.0f;
 	int pivotColumIndex = 0;
 	int pivotRowIndex = 0;
-	float pivot = 0.0;
-	float value1 = 0.0;
-	float value2 = 0.0;
-	float value3 = 0.0;
-	float smallest = 0.0;
+	float pivot = 0.0f;
+	float value1 = 0.0f;
+	float value2 = 0.0f;
+	float value3 = 0.0f;
+	float smallest = 0.0f;
 	int count = 0;
 
 	do {
 		// Find our pivot column
 		pivotColumIndex = 0;
-		entry = 0.0;
+		entry = 0.0f;
 		// -1 because we don't want to count with the last column
-		for (uint8_t i = 0; i < (column_a + row_a + 2) - 1; i++) {
+		for (int i = 0; i < (column_a + row_a + 2) - 1; i++) {
 			value1 =
 				tableau[(row_a + 1 - 1) * (column_a + row_a + 2) + i]; // Bottom row
 			if (value1 < entry) {
@@ -134,16 +134,18 @@ static void opti(float c[], float A[], float b[], float x[], uint8_t row_a, uint
 		pivotRowIndex = 0;
 		value1 = *(tableau + 0 * (column_a + row_a + 2) +
 			   pivotColumIndex); // Value in pivot column
-		if (value1 == 0)
+		if (value1 == 0) {
 			value1 = FLT_EPSILON; // Make sure that we don't divide by zero
+		}
 		value2 = tableau[0 * (column_a + row_a + 2) +
 				 (column_a + row_a + 2 - 1)]; // Value in the b vector
 		smallest = value2 / value1; // Initial smallest value
 		for (int i = 1; i < row_a; i++) {
 			value1 = tableau[i * (column_a + row_a + 2) +
 					 pivotColumIndex]; // Value in pivot column
-			if (value1 == 0)
+			if (value1 == 0) {
 				value1 = FLT_EPSILON;
+			}
 			value2 = tableau[i * (column_a + row_a + 2) +
 					 (column_a + row_a + 2 - 1)]; // Value in the b vector
 			value3 = value2 / value1;
@@ -157,9 +159,10 @@ static void opti(float c[], float A[], float b[], float x[], uint8_t row_a, uint
 		// 1/pivot * PIVOT_ROW -> PIVOT_ROW
 		pivot = tableau[pivotRowIndex * (column_a + row_a + 2) +
 				pivotColumIndex]; // Our pivot value
-		if (pivot == 0)
+		if (pivot == 0) {
 			pivot = FLT_EPSILON;
-		for (uint8_t i = 0; i < (column_a + row_a + 2); i++) {
+		}
+		for (int i = 0; i < (column_a + row_a + 2); i++) {
 			value1 = tableau[pivotRowIndex * (column_a + row_a + 2) +
 					 i]; // Our row value at pivot row
 			tableau[pivotRowIndex * (column_a + row_a + 2) + i] =

--- a/src/sysid/era.c
+++ b/src/sysid/era.c
@@ -7,31 +7,33 @@
  * Training: https://swedishembedded.com/training
  */
 
+#include "control/linalg.h"
+#include "control/misc.h"
+#include "control/sysid.h"
+
+#include <errno.h>
 #include <math.h>
 
-#include <control/linalg.h>
-#include <control/misc.h>
-#include <control/sysid.h>
-
-/*
- * Eigensystem Realization Algorithm.
- * u [m*n] // Input signal
- * y [m*n] // Output signal
- * A [ADIM*ADIM] // System matrix with dimension ADIM*ADIM
- * B [ADIM*inputs_outputs] // Input matrix with dimension ADIM*inputs_outputs
- * C [inputs_outputs*ADIM] // Output matrix with dimension inputs_outputs*ADMIN
- */
-void era(float u[], float y[], uint16_t row, uint16_t column, float A[], float B[], float C[],
-	 uint8_t row_a, uint8_t inputs_outputs)
+int era(float u[], float y[], uint16_t row, uint16_t column, float A[], float B[], float C[],
+	uint8_t row_a, uint8_t inputs_outputs)
 {
+	if ((row == 0) || (column == 0)) {
+		return -EINVAL;
+	}
+	if (row_a == 0) {
+		return -EINVAL;
+	}
+
 	// Markov parameters - Impulse response
 	float g[row * column];
 
 	okid(u, y, g, row, column);
 
 	// Compute the correct dimensions for matrix H
-	uint16_t row_h = row * (column / 2);
-	uint16_t column_h = column / 2;
+	const uint16_t row_h = row * (column / 2);
+	const uint16_t column_h = column / 2;
+
+	float Temp[row_h * column_h]; // Temporary
 
 	// Create Half Hankel matrix
 	float H[row_h * column_h];
@@ -50,30 +52,34 @@ void era(float u[], float y[], uint16_t row, uint16_t column, float A[], float B
 
 	// Create C and B matrix
 	for (uint8_t i = 0; i < row_a; i++) {
-		for (uint8_t j = 0; j < inputs_outputs; j++)
+		for (uint8_t j = 0; j < inputs_outputs; j++) {
 			C[j * row_a + i] = U[j * column_h + i] * sqrtf(S[i]); // C = U*S^(1/2)
+		}
 
-		for (uint8_t j = 0; j < inputs_outputs; j++)
+		for (uint8_t j = 0; j < inputs_outputs; j++) {
 			B[i * inputs_outputs + j] =
 				sqrtf(S[i]) * V[j * column_h + i]; // B = S^(1/2)*V^T
+		}
 	}
 
 	// A = S^(-1/2)*U^T*H*V*S^(-1/2)
 
 	// V = V*S^(-1/2)
-	for (uint16_t i = 0; i < column_h; i++)
-		for (uint16_t j = 0; j < column_h; j++)
+	for (uint16_t i = 0; i < column_h; i++) {
+		for (uint16_t j = 0; j < column_h; j++) {
 			V[j * column_h + i] = V[j * column_h + i] * sqrtf(1 / S[i]);
+		}
+	}
 
 	// U = S^(-1/2)*U^T
 	tran(U, U, row_h, column_h);
-	for (uint16_t i = 0; i < row_h; i++)
-		for (uint16_t j = 0; j < column_h; j++)
+	for (uint16_t i = 0; i < row_h; i++) {
+		for (uint16_t j = 0; j < column_h; j++) {
 			U[j * row_h + i] = sqrtf(1 / S[j]) * U[j * row_h + i];
+		}
+	}
 
 	// Create A matrix: T = H*V
-	float Temp[row_h * column_h]; // Temporary
-
 	mul(Temp, H, V, row_h, column_h, column_h, column_h);
 
 	// Now, multiply V = U(column_h, row_h)*Temp(row_h, column_h). U is transpose!
@@ -81,4 +87,6 @@ void era(float u[], float y[], uint16_t row, uint16_t column, float A[], float B
 
 	// Get the elements of V -> A
 	cut(A, V, column_h, column_h, 0, 0, row_a, row_a);
+
+	return 0;
 }

--- a/src/sysid/okid.c
+++ b/src/sysid/okid.c
@@ -7,20 +7,10 @@
  * Training: https://swedishembedded.com/training
  */
 
-#include <string.h>
-#include <control/sysid.h>
+#include "control/sysid.h"
 
-/*
- * Observer kalman filter identification.
- * This is the basic version, e.g it won't give you the kalman gain K matrix.
- * If you need fully version, then look for MataveID at GitHub
- * First collect your inputs u and outputs y and create impulse response g, called Markov parameters.
- * Then you must use era.c algorithm to convert impulse response g into a linear state space model.
- * Data length need to be the same as the column length n!
- * u [m*n]
- * y [m*n]
- * g [m*n] Markov parameters
- */
+#include <string.h>
+
 void okid(float u[], float y[], float g[], uint16_t row, uint16_t column)
 {
 	/**

--- a/tests/dynamics/c2d.cpp
+++ b/tests/dynamics/c2d.cpp
@@ -19,15 +19,18 @@ TEST(Main, C2D)
 	float B_exp[] = {13.600674, 30.567947};
 	float A[] = { 1, 2, 3, 4 };
 	float B[] = {0, 1};
+	float Ad[4];
+	float Bd[2];
+
 	// clang-format on
 
-	c2d(A, B, 2, 1, 1);
+	c2d(Ad, Bd, A, B, 2, 1, 1);
 
 	for (unsigned int c = 0; c < 4; c++) {
-		ASSERT_FLOAT_EQ(A_exp[c], A[c]);
+		ASSERT_FLOAT_EQ(A_exp[c], Ad[c]);
 	}
 
 	for (unsigned int c = 0; c < 2; c++) {
-		ASSERT_FLOAT_EQ(B_exp[c], B[c]);
+		ASSERT_FLOAT_EQ(B_exp[c], Bd[c]);
 	}
 }

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -5,7 +5,7 @@
 
 config CONTROL
 	bool "Swedish Embedded control engineering library"
-	default y
+	default n
 	depends on NEWLIB_LIBC || EXTERNAL_LIBC
 	help
 		Control engineering algorithm library


### PR DESCRIPTION
This PR contains many small changes and adjustments to make clang-tidy checks pass. 
- Not all clang-tidy checks are enabled. Readability checks result in too many errors so they have not been enabled yet - but some readability issues have been fixed anyway.
- c2d api has been adjusted to match the requirement that we do not modify input matrices. API will be stabilized by v1.0.0. 

Signed-off-by: Martin Schröder <info@swedishembedded.com>